### PR TITLE
Removed constuct_dem.sh from files to install

### DIFF
--- a/doris_core/configure
+++ b/doris_core/configure
@@ -622,7 +622,6 @@ SWOBJS	=	\$(SWSRCS:.cc=.o)
 SCRIPTS	=	helpdoris \
 		baseline.doris.sh \
 		baseline.doris.csh \
-                construct_dem.sh \
 		coregpm.doris \
 		doris* \
 		heightamb \


### PR DESCRIPTION
Removed deprecated script construct_dem.sh from the script list to avoid errors during compiling and installing doris_core.